### PR TITLE
Cache header info

### DIFF
--- a/target_gsheet.py
+++ b/target_gsheet.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import functools
 import io
 import os
 import sys
@@ -117,8 +118,6 @@ def flatten(d, parent_key='', sep='__'):
         else:
             items.append((new_key, str(v) if type(v) is list else v))
     return dict(items)
-
-def set_headers(service, spreadsheet):
 
 def persist_lines(service, spreadsheet, lines):
     state = None


### PR DESCRIPTION
Improved performance by caching whether or not the sheet already has a header line.

Before this change, for every row we append, we check whether the first row in the sheet has values, in order to know whether we should insert a header row or not. Now we cache that information for each sheet, so after we've appended the first row we don't need to check again.

Tested by loading fixerio data under three different test cases:

1. Sheet doesn't exist yet
2. Sheet exists but is empty
3. Sheet exists and is non-empty

Confirmed that in all three cases we end up with a sheet that has exactly one header row and the correct number of data rows.